### PR TITLE
V2.30.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,13 @@ about:
   summary: Typing stubs for requests
   license: Apache-2.0 AND MIT
   license_file: LICENSE
+  license_family: OTHER
+  description: |
+    This is a PEP 561 type stub package for the requests package. 
+    It can be used by type-checking tools like mypy, pyright, pytype, 
+    PyCharm, etc. to check code that uses requests. 
+  dev_url: https://github.com/python/typeshed
+  doc_url: https://requests.readthedocs.io
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<36]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.28.11.12" %}
+{% set version = "2.30.0.0" %}
 
 package:
   name: types-requests
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/t/types-requests/types-requests-{{ version }}.tar.gz
-  sha256: fd530aab3fc4f05ee36406af168f0836e6f00f1ee51a0b96b7311f82cb675230
+  sha256: dec781054324a70ba64430ae9e62e7e9c8e4618c185a5cb3f87a6738251b5a31
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,9 +16,11 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
+    - setuptools
+    - wheel
   run:
-    - python >=3.6
+    - python
     - types-urllib3 <1.27
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,8 @@ requirements:
     - types-urllib3 <1.27
 
 test:
+  imports:
+    - types
   requires:
     - pip
   commands:


### PR DESCRIPTION
[Upstream](https://github.com/python/typeshed)
[Changelog](https://requests.readthedocs.io/en/latest/community/updates/#release-history)

### Actions
- Bump version to 2.30.0.0
- Remove noarch build and update build script
- Update requirements and tests
- Linter fixes